### PR TITLE
Don't swallow exceptions -- throw them up instead

### DIFF
--- a/src/main/java/net/fortuna/ical4j/connector/FailedOperationException.java
+++ b/src/main/java/net/fortuna/ical4j/connector/FailedOperationException.java
@@ -60,7 +60,6 @@ public class FailedOperationException extends Exception {
 	 */
 	public FailedOperationException(Throwable paramThrowable) {
 		super(paramThrowable);
-		// TODO Auto-generated constructor stub
 	}
 
 	/**
@@ -69,7 +68,6 @@ public class FailedOperationException extends Exception {
 	 */
 	public FailedOperationException(String paramString, Throwable paramThrowable) {
 		super(paramString, paramThrowable);
-		// TODO Auto-generated constructor stub
 	}
 
 }

--- a/src/main/java/net/fortuna/ical4j/connector/dav/AbstractDavObjectCollection.java
+++ b/src/main/java/net/fortuna/ical4j/connector/dav/AbstractDavObjectCollection.java
@@ -139,12 +139,8 @@ public abstract class AbstractDavObjectCollection<T> implements ObjectCollection
                     }
                 }
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
 
         return resourceTypes.toArray(new ResourceType[resourceTypes.size()]);
@@ -176,14 +172,10 @@ public abstract class AbstractDavObjectCollection<T> implements ObjectCollection
                     }
                 }
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+            return mediaTypes.toArray(new MediaType[mediaTypes.size()]);
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return mediaTypes.toArray(new MediaType[mediaTypes.size()]);
     }
     
     /**
@@ -195,14 +187,10 @@ public abstract class AbstractDavObjectCollection<T> implements ObjectCollection
             if (calTimezoneProp != null) {
                 return calTimezoneProp;
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+            return new Long(0);
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return new Long(0);
     }
     
     /**
@@ -214,14 +202,10 @@ public abstract class AbstractDavObjectCollection<T> implements ObjectCollection
             if (calTimezoneProp != null) {
                 return calTimezoneProp;
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+            return new Long(0);
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return new Long(0);
     }
     
     /**
@@ -242,14 +226,10 @@ public abstract class AbstractDavObjectCollection<T> implements ObjectCollection
                     }
                 }
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+            return ownerHref;
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return ownerHref;
     }
 
     /**
@@ -278,10 +258,8 @@ public abstract class AbstractDavObjectCollection<T> implements ObjectCollection
                         }
                     }
                 }
-            } catch (IOException e) {
-                e.printStackTrace();
-            } catch (DavException e) {
-                e.printStackTrace();
+            } catch (IOException | DavException e) {
+                throw new RuntimeException(e);
             }
         }
         return _ownerName;
@@ -323,29 +301,12 @@ public abstract class AbstractDavObjectCollection<T> implements ObjectCollection
                     Constructor<P> constructor = type.getConstructor(value.getClass());
                     return constructor.newInstance(value);
                 }
+            } catch (IllegalAccessException
+                    | InvocationTargetException
+                    | InstantiationException
+                    | NoSuchMethodException e) {
+                throw new RuntimeException(e);
             }
-            catch (SecurityException e) {
-                e.printStackTrace();
-            }
-            catch (NoSuchMethodException e) {
-                e.printStackTrace();
-            }
-            catch (IllegalArgumentException e) {
-                e.printStackTrace();
-            }
-            catch (InstantiationException e) {
-                e.printStackTrace();
-            }
-            catch (IllegalAccessException e) {
-                e.printStackTrace();
-            }
-            catch (InvocationTargetException e) {
-                e.printStackTrace();
-            }
-            catch (NullPointerException e) {
-                e.printStackTrace();                
-            }
-            return (P) props.get(propertyName).getValue();
         }
         return null;
     }

--- a/src/main/java/net/fortuna/ical4j/connector/dav/CalDavCalendarCollection.java
+++ b/src/main/java/net/fortuna/ical4j/connector/dav/CalDavCalendarCollection.java
@@ -63,6 +63,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
+import javax.swing.text.html.parser.Parser;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
@@ -185,21 +186,12 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
             getStore().getClient().execute(method);
             if (method.getStatusCode() == DavServletResponse.SC_MULTI_STATUS) {
                 return method.getCalendars();
-            } else if (method.getStatusCode() == DavServletResponse.SC_NOT_FOUND) {
+            } else {
                 return new Calendar[0];
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (DOMException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
-        } catch (ParserException e) {
-            e.printStackTrace();
-        } catch (ParserConfigurationException e) {
-            e.printStackTrace();
+        } catch (DavException | IOException | ParserConfigurationException | ParserException e) {
+            throw new RuntimeException(e);
         }
-        return new Calendar[0];
     }
 
     /**
@@ -208,14 +200,9 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
     public String getDescription() {
         try {
             return getProperty(CalDavPropertyName.CALENDAR_DESCRIPTION, String.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     /**
@@ -224,14 +211,9 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
     public String getDisplayName() {
         try {
             return getProperty(DavPropertyName.DISPLAYNAME, String.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     /**
@@ -241,14 +223,9 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
     public Integer getMaxAttendeesPerInstance() {
         try {
             return getProperty(CalDavPropertyName.MAX_ATTENDEES_PER_INSTANCE, Integer.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return 0;
     }
 
     /**
@@ -258,14 +235,9 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
     public String getMaxDateTime() {
         try {
             return getProperty(CalDavPropertyName.MAX_DATE_TIME, String.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     /**
@@ -275,14 +247,9 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
     public Integer getMaxInstances() {
         try {
             return getProperty(CalDavPropertyName.MAX_INSTANCES, Integer.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return 0;
     }
 
     /**
@@ -295,14 +262,10 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
             if (size != null) {
                 return size;
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+            return 0;
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return 0;
     }
 
     /**
@@ -312,14 +275,9 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
     public String getMinDateTime() {
         try {
             return getProperty(CalDavPropertyName.MIN_DATE_TIME, String.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     /**
@@ -341,12 +299,8 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
                     }
                 }
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
 
         return supportedComponents.toArray(new String[supportedComponents.size()]);
@@ -364,46 +318,26 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
                 CalendarBuilder builder = new CalendarBuilder();
                 return builder.build(new StringReader(calTimezoneProp));
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ParserException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
-        } 
-        return new Calendar();
+            return new Calendar();
+        } catch (ObjectStoreException | IOException | DavException | ParserException e) {
+            throw new RuntimeException(e);
+        }
     }
     
     public String getColor() {
         try {
             return getProperty(ICalPropertyName.CALENDAR_COLOR, String.class);
-        } catch (NullPointerException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return null;
     }
     
     public int getOrder() {
         try {
             return getProperty(ICalPropertyName.CALENDAR_ORDER, Integer.class);
-        } catch (NullPointerException e) {
-            e.printStackTrace();            
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return 1;
     }
 
     /**
@@ -471,18 +405,14 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
         GetMethod method = new GetMethod(path + uid + ".ics");
         try {
             getStore().getClient().execute(method);
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
         if (method.getStatusCode() == DavServletResponse.SC_OK) {
             try {
                 return method.getCalendar();
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            } catch (ParserException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+            } catch (IOException | ParserException e) {
+                throw new RuntimeException(e);
             }
         } else if (method.getStatusCode() == DavServletResponse.SC_NOT_FOUND) {
             return null;
@@ -527,8 +457,7 @@ public class CalDavCalendarCollection extends AbstractDavObjectCollection<Calend
      * {@inheritDoc}
      */
     public Calendar export() throws ObjectStoreException {
-        // TODO Auto-generated method stub
-        return null;
+        throw new UnsupportedOperationException("not implemented");
     }
 
     /**

--- a/src/main/java/net/fortuna/ical4j/connector/dav/CalDavCalendarStore.java
+++ b/src/main/java/net/fortuna/ical4j/connector/dav/CalDavCalendarStore.java
@@ -128,8 +128,7 @@ public final class CalDavCalendarStore extends AbstractDavObjectStore<CalDavCale
         try {
             collection.create();
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            throw new ObjectStoreException(String.format("unable to add collection '%s'", id), e);
         }
         return collection;
     }
@@ -144,8 +143,7 @@ public final class CalDavCalendarStore extends AbstractDavObjectStore<CalDavCale
         try {
             collection.create();
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            throw new ObjectStoreException(String.format("unable to add collection '%s'", id), e);
         }
         return collection;
     }
@@ -158,8 +156,7 @@ public final class CalDavCalendarStore extends AbstractDavObjectStore<CalDavCale
         try {
             collection.create();
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            throw new ObjectStoreException(String.format("unable to add collection '%s'", id), e);
         }
         return collection;
     }
@@ -178,22 +175,16 @@ public final class CalDavCalendarStore extends AbstractDavObjectStore<CalDavCale
             MultiStatusResponse[] responses = multiStatus.getResponses();
 
             return CalDavCalendarCollection.collectionsFromResponse(this, responses).get(0);
-        } catch (HttpException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (IOException | DavException e) {
+            throw new ObjectStoreException(String.format("unable to get collection '%s'", id), e);
         }
-        throw new ObjectNotFoundException("Collection with id: [" + id + "] not found");
     }
 
     /**
      * {@inheritDoc}
      */
     public CalendarCollection merge(String id, CalendarCollection calendar) {
-        // TODO Auto-generated method stub
-        return null;
+        throw new UnsupportedOperationException("not implemented");
     }
 
     public String findCalendarHomeSet() throws ParserConfigurationException, IOException, DavException {
@@ -475,10 +466,8 @@ public final class CalDavCalendarStore extends AbstractDavObjectStore<CalDavCale
         CalDavCalendarCollection collection = getCollection(id);
         try {
             collection.delete();
-        } catch (HttpException e) {
-            e.printStackTrace();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new ObjectStoreException(String.format("unable to remove collection '%s'", id), e);
         }
         return collection;
     }

--- a/src/main/java/net/fortuna/ical4j/connector/dav/CardDavCollection.java
+++ b/src/main/java/net/fortuna/ical4j/connector/dav/CardDavCollection.java
@@ -130,14 +130,9 @@ public class CardDavCollection extends AbstractDavObjectCollection<VCard> implem
     public String getDisplayName() {
         try {
             return getProperty(DavPropertyName.DISPLAYNAME, String.class);
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     /**
@@ -150,12 +145,8 @@ public class CardDavCollection extends AbstractDavObjectCollection<VCard> implem
             if (size != null) {
                 return size;
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (ObjectStoreException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (ObjectStoreException | IOException | DavException e) {
+            throw new RuntimeException(e);
         }
         return 0;
     }
@@ -164,8 +155,7 @@ public class CardDavCollection extends AbstractDavObjectCollection<VCard> implem
      * {@inheritDoc}
      */
     public Calendar export() throws ObjectStoreException {
-        // TODO Auto-generated method stub
-        return null;
+        throw new UnsupportedOperationException("not implemented");
     }
         
     public static final DavPropertyNameSet propertiesForFetch() {
@@ -282,15 +272,9 @@ public class CardDavCollection extends AbstractDavObjectCollection<VCard> implem
             } else if (method.getStatusCode() == DavServletResponse.SC_NOT_FOUND) {
                 return new VCard[0];
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (DOMException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
-        } /* catch (ParserException e) {
-            e.printStackTrace();
-        } */
+        } catch (IOException | DavException e) {
+            throw new RuntimeException(e);
+        }
         return new VCard[0];
     }
 

--- a/src/main/java/net/fortuna/ical4j/connector/dav/CardDavStore.java
+++ b/src/main/java/net/fortuna/ical4j/connector/dav/CardDavStore.java
@@ -113,8 +113,7 @@ public final class CardDavStore extends AbstractDavObjectStore<CardDavCollection
         try {
             collection.create();
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            throw new ObjectStoreException(String.format("unable to add collection '%s'", id), e);
         }
         return collection;
     }
@@ -127,8 +126,7 @@ public final class CardDavStore extends AbstractDavObjectStore<CardDavCollection
         try {
             collection.create();
         } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            throw new ObjectStoreException(String.format("unable to add collection '%s'", id), e);
         }
         return collection;
     }
@@ -147,22 +145,16 @@ public final class CardDavStore extends AbstractDavObjectStore<CardDavCollection
             MultiStatusResponse[] responses = multiStatus.getResponses();
 
             return CardDavCollection.collectionsFromResponse(this, responses).get(0);
-        } catch (HttpException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (DavException e) {
-            e.printStackTrace();
+        } catch (IOException | DavException e) {
+            throw new ObjectStoreException(String.format("unable to get collection '%s'", id), e);
         }
-        throw new ObjectNotFoundException("Collection with id: [" + id + "] not found");
     }
 
     /**
      * {@inheritDoc}
      */
     public CalendarCollection merge(String id, CalendarCollection calendar) {
-        // TODO Auto-generated method stub
-        return null;
+        throw new UnsupportedOperationException("not implemented");
     }
 
     protected String findAddressBookHomeSet() throws ParserConfigurationException, IOException, DavException {
@@ -256,12 +248,8 @@ public final class CardDavStore extends AbstractDavObjectStore<CardDavCollection
             }
             String urlForcalendarHomeSet = getHostURL() + calHomeSetUri;
             return getCollectionsForHomeSet(this, urlForcalendarHomeSet);
-        } catch (DavException de) {
-            throw new ObjectStoreException(de);
-        } catch (IOException ioe) {
-            throw new ObjectStoreException(ioe);
-        } catch (ParserConfigurationException pce) {
-            throw new ObjectStoreException(pce);
+        } catch (DavException | IOException | ParserConfigurationException e) {
+            throw new ObjectStoreException(e);
         }
     }
     
@@ -438,10 +426,8 @@ public final class CardDavStore extends AbstractDavObjectStore<CardDavCollection
         CardDavCollection collection = getCollection(id);
         try {
             collection.delete();
-        } catch (HttpException e) {
-            e.printStackTrace();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new ObjectStoreException(String.format("unable to remove collection '%s'", id), e);
         }
         return collection;
     }
@@ -471,8 +457,7 @@ public final class CardDavStore extends AbstractDavObjectStore<CardDavCollection
      */
     public CardDavCollection addCollection(String id, String displayName, String description,
             String[] supportedComponents, Calendar timezone) throws ObjectStoreException {
-        // TODO Auto-generated method stub
-        return null;
+        throw new UnsupportedOperationException("not implemented");
     }
 
 }


### PR DESCRIPTION
Exceptions, and in particular `IOException` in networking code, should not be swallowed but thrown up to the caller, such that an appropriate error message can be generated for the end user. The client is still free to wrap all `ical4j`-Methods in a catch-all `try-catch`.

I made a fairly mechanic change to all the catch clauses:

 * replace `e.printStackTrace()` with `throw new RuntimeException(..., e)` for all checked exception's `catch` clauses.
 * remove `catch` clauses for `NullPointerException` in `AbstractDavObjectCollection::getProperty(DavPropertyName propertyName, Class<P> type)`
 * `throw UnsupportedOperationException(...)` in obviously unimplemented methods
 * No method signatures were changed