### PR TITLE
only require one resource type to count as a calendar collection

### DIFF
--- a/ical4j-connector-dav/src/main/java/org/ical4j/connector/dav/response/GetCollections.java
+++ b/ical4j-connector-dav/src/main/java/org/ical4j/connector/dav/response/GetCollections.java
@@ -30,8 +30,10 @@ public class GetCollections extends AbstractResponseHandler<Map<String, DavPrope
         try {
             var multiStatus = getMultiStatus(response);
             return Arrays.stream(multiStatus.getResponses())
-                    .filter(msr -> resourceTypes.containsAll(
-                            (List<Element>) msr.getProperties(HttpStatus.SC_OK).get(DavPropertyName.RESOURCETYPE).getValue()))
+                    .filter(msr -> {
+                        List<Element> resourceType = (List<Element>) msr.getProperties(HttpStatus.SC_OK).get(DavPropertyName.RESOURCETYPE).getValue();
+                        return resourceType.stream().anyMatch(resourceType::contains);
+                    })
                     .collect(Collectors.toMap(MultiStatusResponse::getHref,
                             msr -> msr.getProperties(HttpStatus.SC_OK)));
         } catch (DavException e) {


### PR DESCRIPTION
Until release 1.0.4 it was enough to only have one of the resource types in order to count as a calendar collection. 

we are using sabredav and the resource type list looks like this

```
<d:resourcetype>
   <d:collection/>
   <cal:calendar/>
   <cs:shared-owner/>
</d:resourcetype>
```