### PR TITLE
fix: if-match and if-none-match header are present on the same request

### DIFF
--- a/ical4j-connector-dav/src/main/java/org/ical4j/connector/dav/method/AbstractPutMethod.java
+++ b/ical4j-connector-dav/src/main/java/org/ical4j/connector/dav/method/AbstractPutMethod.java
@@ -19,6 +19,9 @@ class AbstractPutMethod extends HttpPut {
     }
 
     public void setEtag(String etag) {
+        removeHeaders("If-None-Match");
+        removeHeaders("If-Match");
+
         if (etag != null) {
             addHeader("If-Match", etag);
         } else {


### PR DESCRIPTION
Calling `setEtag` adds the header without removing previously added headers. This can lead to having multiples of the same header or conflicting headers like `if-match='*'` and `if-none-match='*'`


The error happens during the call `writeCalendarOnServer` when the parameter `isNew` is `false`

1. The `AbstractPutMethod` constructor calls `setEtag(null)`
2. The `put` method in the `DefaultDavClient`calls `setEtag("*")`